### PR TITLE
Added ConsentStatus.AD_FREE_PREFERRED

### DIFF
--- a/consent-library/src/main/java/com/google/ads/consent/ConsentForm.java
+++ b/consent-library/src/main/java/com/google/ads/consent/ConsentForm.java
@@ -319,7 +319,7 @@ public class ConsentForm {
                 break;
             case "ad_free":
                 userPrefersAdFree = true;
-                consentStatus = ConsentStatus.UNKNOWN;
+                consentStatus = ConsentStatus.AD_FREE_PREFERRED;
                 break;
             default:
                 consentStatus = ConsentStatus.UNKNOWN;

--- a/consent-library/src/main/java/com/google/ads/consent/ConsentInformation.java
+++ b/consent-library/src/main/java/com/google/ads/consent/ConsentInformation.java
@@ -478,7 +478,7 @@ public class ConsentInformation {
 
     protected synchronized void setConsentStatus(ConsentStatus consentStatus, String source) {
         ConsentData consentData = this.loadConsentData();
-        if (consentStatus == ConsentStatus.UNKNOWN) {
+        if ((consentStatus == ConsentStatus.UNKNOWN) || ( consentStatus == ConsentStatus.AD_FREE_PREFERRED)) {
             consentData.setConsentedAdProviders(new HashSet<AdProvider>());
         } else {
             consentData.setConsentedAdProviders(consentData.getAdProviders());

--- a/consent-library/src/main/java/com/google/ads/consent/ConsentStatus.java
+++ b/consent-library/src/main/java/com/google/ads/consent/ConsentStatus.java
@@ -27,4 +27,6 @@ public enum ConsentStatus {
     NON_PERSONALIZED,
     @SerializedName("personalized")
     PERSONALIZED,
+    @SerializedName("ad_free_preferred")
+    AD_FREE_PREFERRED,
 }


### PR DESCRIPTION
When getting consent, the return of ConsentStatus.UNKNOWN for the user preferring an ad-free version is confusing, as it also is the return for the consent being unknown.  In addition, having UNKNOWN returned when retrieving the status when the user prefers an ad-free version is also a confusing issue.  Granted, if an app is using an in-app purchase to remove ads, then the consent status dialog should not come up, but it would be nice to have that status available if the user has reinstalled, or installed on another device.