### PR TITLE
remove unsupported build information from manifest file

### DIFF
--- a/consent-library/src/main/AndroidManifest.xml
+++ b/consent-library/src/main/AndroidManifest.xml
@@ -2,8 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.android.ads.consent" >
 
-  <uses-sdk
-      android:minSdkVersion="14"
-      android:targetSdkVersion="26" />
-
 </manifest>


### PR DESCRIPTION
Newer gradle versions do not allow us to include minSdkVersion and targetSdkVersion in the manifest file.